### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -21,7 +26,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: pnpm install
@@ -50,4 +56,3 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,17 +35,6 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Import GPG Key
-        # cspell: disable-next-line
-        uses: crazy-max/ghaction-import-gpg@v7
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          # cspell: disable-next-line
-          git_user_signingkey: true
-          # cspell: disable-next-line
-          git_commit_gpgsign: true
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -53,6 +42,4 @@ jobs:
           publish: pnpm run changeset:publish
           commit: 'chore(changesets): version packages'
           title: 'chore(changesets): version packages'
-          setupGitUser: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          commitMode: github-api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@donniean/node-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "homepage": "https://github.com/donniean/node-app#readme",
   "bugs": {
     "url": "https://github.com/donniean/node-app/issues"


### PR DESCRIPTION
## Summary

- Configure the release workflow for npm Trusted Publishers by enabling OIDC and npm registry setup.
- Remove npm token and custom GitHub token usage from the Changesets release step.
- Switch Changesets to `commitMode: github-api` and remove the local GPG import step.

## Validation

- `yq eval '.' .github/workflows/release.yaml >/dev/null`
- `pnpm run lint:format`

`actionlint` was not run because it is not installed locally.