### PR TITLE
ci(gh-actions): update workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   bump:
+    permissions:
+      contents: read
     uses: donniean/hub/.github/workflows/dependencies.bump.yaml@main
     with:
       app-client-id: ${{ vars.APP_CLIENT_ID }}

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   bump:
     uses: donniean/hub/.github/workflows/dependencies.bump.yaml@main
+    with:
+      app-client-id: ${{ vars.APP_CLIENT_ID }}
     secrets:
-      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   auto-merge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -4,4 +4,7 @@ on:
 
 jobs:
   auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: donniean/hub/.github/workflows/pull-requests.auto-merge.yaml@main

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -4,7 +4,6 @@ on:
 
 jobs:
   auto-merge:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -5,5 +5,7 @@ on:
 jobs:
   auto-update:
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
+    with:
+      app-client-id: ${{ vars.APP_CLIENT_ID }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   auto-update:
+    permissions: {}
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
     with:
       app-client-id: ${{ vars.APP_CLIENT_ID }}

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -6,5 +6,4 @@ jobs:
   auto-update:
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Add explicit least-privilege `GITHUB_TOKEN` permissions to CI and reusable workflow caller jobs.
- Pass the GitHub App client ID through repository variables for dependency bump and auto-update workflows.
- Keep GitHub App private key usage in repository secrets and remove the old APP_ID secret dependency from workflow inputs.

## Validation

- `yq eval '.' .github/workflows/*.yaml >/dev/null`
- `pnpm exec prettier --check .github/workflows/*.yaml`
- `actionlint 1.7.12`
