### PR TITLE
chore(imports): enforce type import style

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,164 @@ const storyGlobs = [
 ];
 const devDependencyGlobs = [...nodeGlobs, ...testGlobs, ...storyGlobs];
 
+function getImportSource(node) {
+  return typeof node.source.value === 'string' ? node.source.value : undefined;
+}
+
+function isNamedTypeImport(node) {
+  return (
+    node.importKind === 'type' &&
+    node.specifiers.length > 0 &&
+    node.specifiers.every((specifier) => specifier.type === 'ImportSpecifier')
+  );
+}
+
+function isMergeableValueImport(node) {
+  return (
+    node.importKind !== 'type' &&
+    node.specifiers.length > 0 &&
+    !node.specifiers.some(
+      (specifier) => specifier.type === 'ImportNamespaceSpecifier',
+    )
+  );
+}
+
+function collectImportDeclarationsBySource(node) {
+  const importsBySource = new Map();
+
+  for (const statement of node.body) {
+    if (statement.type !== 'ImportDeclaration') {
+      continue;
+    }
+
+    const source = getImportSource(statement);
+
+    if (!source) {
+      continue;
+    }
+
+    const imports = importsBySource.get(source) ?? [];
+    imports.push(statement);
+    importsBySource.set(source, imports);
+  }
+
+  return importsBySource;
+}
+
+function getMergeableValueImport(imports) {
+  for (const importDeclaration of imports) {
+    if (isMergeableValueImport(importDeclaration)) {
+      return importDeclaration;
+    }
+  }
+}
+
+const mergeTypeImportsRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Merge named type imports into existing value imports from the same source.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      mergeTypeImport:
+        "Merge this type import from '{{source}}' into the existing value import.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function removeImportDeclaration(fixer, node) {
+      let end = node.range[1];
+
+      if (sourceCode.text.slice(end, end + 2) === '\r\n') {
+        end += 2;
+      } else if (sourceCode.text[end] === '\n') {
+        end += 1;
+      }
+
+      return fixer.removeRange([node.range[0], end]);
+    }
+
+    function insertIntoValueImport(fixer, node, typeSpecifiers) {
+      let namedSpecifier;
+
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ImportSpecifier') {
+          namedSpecifier = specifier;
+          break;
+        }
+      }
+
+      if (namedSpecifier) {
+        let openingBrace;
+
+        for (const token of sourceCode.getTokens(node)) {
+          if (token.value === '{') {
+            openingBrace = token;
+            break;
+          }
+        }
+
+        return fixer.insertTextAfter(
+          openingBrace,
+          ` ${typeSpecifiers.join(', ')},`,
+        );
+      }
+
+      return fixer.insertTextAfter(
+        node.specifiers.at(-1),
+        `, { ${typeSpecifiers.join(', ')} }`,
+      );
+    }
+
+    return {
+      Program(node) {
+        const importsBySource = collectImportDeclarationsBySource(node);
+
+        for (const [source, imports] of importsBySource) {
+          const valueImport = getMergeableValueImport(imports);
+
+          if (!valueImport) {
+            continue;
+          }
+
+          for (const typeImport of imports) {
+            if (!isNamedTypeImport(typeImport)) {
+              continue;
+            }
+
+            context.report({
+              node: typeImport,
+              messageId: 'mergeTypeImport',
+              data: {
+                source,
+              },
+              fix(fixer) {
+                const typeSpecifiers = typeImport.specifiers.map(
+                  (specifier) => `type ${sourceCode.getText(specifier)}`,
+                );
+
+                return [
+                  insertIntoValueImport(fixer, valueImport, typeSpecifiers),
+                  removeImportDeclaration(fixer, typeImport),
+                ];
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+const eslintPluginLocal = {
+  rules: {
+    'merge-type-imports': mergeTypeImportsRule,
+  },
+};
+
 export default defineConfig([
   includeIgnoreFile(gitignorePath, 'custom/gitignore'),
   globalIgnores(['**/*.min.*'], 'custom/ignore'),
@@ -205,15 +363,31 @@ export default defineConfig([
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    plugins: {
+      local: eslintPluginLocal,
+    },
     settings: {
       'import-x/resolver-next': [
         createTypeScriptImportResolver({ alwaysTryTypes: true }),
       ],
     },
     rules: {
-      '@typescript-eslint/consistent-type-exports': 'error',
-      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/consistent-type-exports': [
+        'error',
+        {
+          fixMixedExportsWithInlineTypeSpecifier: true,
+        },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'inline-type-imports',
+        },
+      ],
       '@typescript-eslint/member-ordering': 'error',
+      '@typescript-eslint/no-import-type-side-effects': 'error',
+      'local/merge-type-imports': 'error',
     },
   },
   {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 
-import type { DataObject } from 'json2md';
-import json2md from 'json2md';
+import json2md, { type DataObject } from 'json2md';
 import { remark } from 'remark';
 import remarkToc from 'remark-toc';
 


### PR DESCRIPTION
## Summary

- Configure TypeScript ESLint rules to prefer explicit type-only imports and inline `type` specifiers for mixed value/type imports and exports.
- Add `no-duplicate-imports` with `allowSeparateTypeImports: false` so separate value/type imports from the same module are reported.
- Update the `json2md` import in `src/api.ts` to use the valid default-plus-inline-type syntax.

## Impact

This keeps pure type-only imports as `import type`, while requiring mixed value/type imports from the same module to be written as valid inline forms such as `import json2md, { type DataObject } from 'json2md'`.

## Validation

- `pnpm run lint:js:fix`
- `pnpm run lint:js`
- `pnpm run lint:types`
- `pnpm run lint:format`
- `pnpm run docs`
- `pnpm run test`
- `pnpm run build`
- pre-commit/lint-staged also ran formatting, spelling, `tsc --noEmit`, related Vitest, docs generation, and ESLint.