### PR TITLE
style(lint): update import and export lint conventions

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -65,6 +65,12 @@ export default defineConfig({
     'eslint/no-var': 'error',
     'eslint/prefer-const': 'error',
     'eslint/prefer-template': 'error',
+    'eslint/sort-imports': [
+      'error',
+      {
+        ignoreDeclarationSort: true,
+      },
+    ],
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-cycle': 'error',
@@ -72,11 +78,24 @@ export default defineConfig({
       'error',
       {
         considerQueryString: true,
+        preferInline: true,
       },
     ],
     'import/no-unassigned-import': ['error', { allow: ['../dist/cli.js'] }],
-    'typescript/consistent-type-exports': 'error',
-    'typescript/consistent-type-imports': 'error',
+    'typescript/consistent-type-exports': [
+      'error',
+      {
+        fixMixedExportsWithInlineTypeSpecifier: true,
+      },
+    ],
+    'typescript/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+        disallowTypeAnnotations: true,
+      },
+    ],
     'typescript/no-empty-object-type': 'error',
     'typescript/no-explicit-any': 'error',
     'typescript/no-import-type-side-effects': 'error',

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 
-import type { DataObject } from 'json2md';
-import json2md from 'json2md';
+import json2md, { type DataObject } from 'json2md';
 import { remark } from 'remark';
 import remarkToc from 'remark-toc';
 


### PR DESCRIPTION
## Summary

- Configure Oxlint to prefer inline type specifiers for mixed imports and exports.
- Enable named import member sorting while leaving import declaration ordering to Oxfmt.
- Merge the `json2md` value/type imports to satisfy the updated duplicate-import convention.

## Validation

- `pnpm run lint:oxlint`
- `pnpm run format:oxfmt:check`
- `pnpm run docs`
- `pnpm run typecheck`
- `pnpm run test`
