### PR TITLE
chore(deps): block TypeScript major updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,9 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - version-update:semver-major
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-major
     cooldown:
       default-days: 1
     open-pull-requests-limit: 999

--- a/.ncurc.mjs
+++ b/.ncurc.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'npm-check-updates';
 
-const majorLockedDependencies = new Set(['@types/node']);
+const majorLockedDependencies = new Set(['@types/node', 'typescript']);
 
 export default defineConfig({
   target: (dependencyName) => {


### PR DESCRIPTION
## Summary

- Ignore semantic-version major updates for `typescript` in Dependabot.
- Keep `npm-check-updates` on the installed TypeScript major while allowing minor and patch updates.

## Motivation

The project and its reusable template currently use TypeScript 6 and workspace TypeScript editor settings. Preventing automatic major upgrades avoids moving to TypeScript 7 before the editor and build toolchain migration is evaluated, while preserving maintenance updates within the current major.

## Impact

This changes dependency-update policy only. TypeScript 6 minor and patch updates remain eligible, and package, CLI, generated documentation, and runtime behavior are unchanged.

## Validation

- `yq eval '.' .github/dependabot.yaml`
- `pnpm run format:oxfmt:check`
- `pnpm run lint:oxlint`
- `pnpm exec ncu --filter typescript --jsonUpgraded` returned `{}`
- `git diff --check`
- Repository commit hooks completed successfully