### PR TITLE
chore: refresh pnpm allow builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 allowBuilds:
   esbuild: true
-  unrs-resolver: true
 engineStrict: true
 minimumReleaseAge: 1440
 overrides:


### PR DESCRIPTION
Reset pnpm build approvals for the current install environment and approve all discovered pending builds. Generated by `scripts/update/pnpm-allow-builds.sh`.