### PR TITLE
ci: cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- cancel stale CI runs for the same ref
- keep release runs non-cancelable because they can publish packages or update the Changesets release pull request

## Impact

New commits on a pull request no longer leave obsolete lint, test, and build runs consuming GitHub Actions time.

## Validation

- `yq eval '.'` for all workflow YAML files
- `pnpm run format:oxfmt:check`
- repository pre-commit checks