### PR TITLE
fix(tooling): ignore unmatched oxlint patterns

### DIFF
--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -12,6 +12,6 @@ export default {
     () => 'pnpm run docs',
     () => 'git add configs.md',
   ],
-  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix',
+  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix --no-error-on-unmatched-pattern',
   '*.md': 'markdownlint --dot --fix',
 } satisfies Configuration;


### PR DESCRIPTION
## Summary

- allow the staged Oxlint task to succeed when its input contains no lintable files
- preserve failures for actual Oxlint diagnostics

## Why

`lint-staged` can select JavaScript or TypeScript paths that Oxlint subsequently excludes. Without `--no-error-on-unmatched-pattern`, that valid no-op case can block the commit even though there is nothing to report.

## Validation

- `pnpm run docs` with no generated `configs.md` diff
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
- pre-commit `lint-staged` hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 优化 JavaScript/TypeScript 文件的提交前检查：即使没有匹配的文件，也不会报告错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->