### PR TITLE
style(tsconfig): reorder compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,11 +49,11 @@
     /* Modules */
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"]
     },
-    "ignoreDeprecations": "6.0",
-    "types": ["node"]
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*", "*.ts", "*.mts", "*.cts"]
 }


### PR DESCRIPTION
## Summary

- move `types` before `paths` in the Node-specific module options
- keep the effective TypeScript configuration unchanged

## Motivation

Keep the compiler options in the intended ordering without changing project behavior.

## Impact

No runtime, build, CLI, API, generated documentation, or template behavior changes are expected. This is a configuration-only ordering change.

## Validation

- `pnpm run lint`
- `pnpm run test` (12 tests passed)
- `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **其他**
  * 调整 TypeScript 编译器选项的排列顺序，配置值和编译行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->